### PR TITLE
Add file size info for WAV

### DIFF
--- a/source/includes/_messages.md
+++ b/source/includes/_messages.md
@@ -795,6 +795,7 @@ Before a WAV file will be played, it needs to conform to a certain criteria.
 
  - All WAV files must be 8bit, 8000Hz, 1ch, 64kbps MAX.
  - If the WAV is supplied outside of these criteria, the TTS will be used instead.  It is vital that TTS is provided even when using WAV files.
+ - All of the WAV files combined, may not exceed 10MB in total file size.
 
 ### Notes:
 


### PR DESCRIPTION
as per Usama, "total size of all the attachments., i.e. total size of attachments _in a message_ can't exceed 10MB limit."  Added this information to the WAV file section for voice messages.